### PR TITLE
Fixed non english chars encoding to html entities

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function ( opt )
 			return callback(new gutil.PluginError('gulp-minify-inline', 'doesn\'t support Streams'));
 		}
 
-		var $ = cheerio.load(file.contents.toString());
+		var $ = cheerio.load(file.contents.toString(), {decodeEntities: false});
 
 		var has_done_nothing = true;
 


### PR DESCRIPTION
<code>Новый</code> should not be encoded to
````html
&#x41D;&#x43E;&#x432;&#x44B;&#x439;
````
Also commit touches [the issue](https://github.com/shkuznetsov/gulp-minify-inline/issues/3).